### PR TITLE
Update to Current Nightly Version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ clean-gen-files:
 # === Vendoring of R8 ===
 vendor-r8:
 	@echo "$(CYAN)📦 Vendoring R8...$(RESET)"
-	mkdir -p ./vendor && curl -L -o ./vendor/r8.jar https://maven.google.com/com/android/tools/r8/8.9.35/r8-8.9.35.jar
+	mkdir -p ./vendor && curl -L -o ./vendor/r8.jar https://maven.google.com/com/android/tools/r8/8.11.18/r8-8.11.18.jar
 	@echo "$(CYAN)📦 R8 vendored!$(RESET)"
 
 clean-vendor-r8:

--- a/java-linker/Cargo.lock
+++ b/java-linker/Cargo.lock
@@ -259,6 +259,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,10 +302,20 @@ dependencies = [
 name = "java-linker"
 version = "0.1.0"
 dependencies = [
+ "java-locator",
  "regex",
  "ristretto_classfile",
  "tempfile",
  "zip",
+]
+
+[[package]]
+name = "java-locator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c46c1fe465c59b1474e665e85e1256c3893dd00927b8d55f63b09044c1e64f"
+dependencies = [
+ "glob",
 ]
 
 [[package]]

--- a/java-linker/Cargo.toml
+++ b/java-linker/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+java-locator = { version = "0.1.9", features = ["locate-jdk-only"] }
 regex = "1.11.1"
 ristretto_classfile = "0.17.0"
 tempfile = "3.19.1"

--- a/src/lower1/control_flow.rs
+++ b/src/lower1/control_flow.rs
@@ -443,6 +443,9 @@ pub fn convert_basic_block<'tcx>(
                     rustc_middle::mir::AssertKind::ResumedAfterDrop(_) => {
                         "ResumedAfterDrop".to_string()
                     }
+                    rustc_middle::mir::AssertKind::InvalidEnumConstruction(_) => {
+                        "InvalidEnumConstruction".to_string()
+                    }
                 };
 
                 let fail_instructions = vec![oomir::Instruction::ThrowNewWithMessage {

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -1,0 +1,22 @@
+use rustc_hir::{ImplItemId, TraitItemId};
+use rustc_middle::ty::TyCtxt;
+use rustc_span::symbol::Ident;
+
+pub trait ToIdent {
+    fn to_ident(&self, tcx: TyCtxt<'_>) -> Ident;
+}
+
+impl ToIdent for &ImplItemId {
+    // TODO: Filter results to get exactly what we need, instead of relying on iterating.
+    fn to_ident(&self, tcx: TyCtxt<'_>) -> Ident {
+        tcx.associated_item(self.owner_id).ident(tcx)
+    }
+}
+
+impl ToIdent for &TraitItemId {
+    // TODO: Filter results to get exactly what we need, instead of relying on iterating.
+    fn to_ident(&self, tcx: TyCtxt<'_>) -> Ident {
+        println!("associated items: ");
+        tcx.associated_item(self.owner_id).ident(tcx)
+    }
+}


### PR DESCRIPTION
# Changes

## Non-Rust

* Update R8 to 8.11.18 (from 8.9.35)
* Source code was formatted with `cargo fmt`

## Rust Changes

* Updated to current nightly (at the time of writing), which is rust version 1.91-nightly.
* Added trait for converting implemented items to `Ident`s with TyCtxt.
  * This stems from the change, introduced rust-lang/rust#143357, which replaces `*ItemRef` with `*ItemId`. So we have to get the [`AssocItem`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/struct.AssocItem.html) from the function [`TyCtxt::associated_item`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/struct.TyCtxt.html#method.associated_item), which we can the get the `Ident` from.
  * Currently only implemented for [`ImplItemId`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/hir/struct.ImplItemId.html) and [`TraitItemId`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/hir/struct.TraitItemId.html).
* Java home is first attempted to be located using [java-locator](https://crates.io/crates/java_locator), if that fails, it then uses "JAVA_HOME".

# Breaks

* The `just_main_fn` test. I don't know why, but I am looking into it.