### PR TITLE
Fix Windows build errors and enable CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,21 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    name: Build and test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    env:
+      PYTHONUTF8: '1'
 
     steps:
+    - name: Enable Git symlinks on Windows
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: git config --global core.symlinks true
+
     - name: Checkout repository
       uses: actions/checkout@v4
 
@@ -33,12 +45,12 @@ jobs:
 
     - name: Cache cargo dependencies
       uses: Swatinem/rust-cache@v2
-    
+ 
     - name: Build backend and tools
-      run: python3 build.py ci
+      run: python build.py ci
 
     - name: Run integration tests (debug mode)
-      run: python3 Tester.py
+      run: python Tester.py
 
     - name: Run integration tests (release mode)
-      run: python3 Tester.py --release
+      run: python Tester.py --release

--- a/Readme.md
+++ b/Readme.md
@@ -133,19 +133,26 @@ Because output is standard JVM bytecode rather than a native binary, `rustc_code
 
 - **Rust Nightly** - `rustup default nightly`
 - **JDK 8+** - `java`, `javac`, and `jar` must be on `PATH`
-- **Python 3** - `python3` must be on `PATH`
+- **Python 3** - `python` must resolve to Python 3 (`python3` can be substituted on local Linux systems that do not provide the `python` alias)
+- **Windows only:** enable [Developer Mode](https://learn.microsoft.com/windows/apps/get-started/enable-your-device-for-development) or run Git from an elevated terminal so it can create symbolic links
 
 ## Installation & Build
 
-Clone the repository and build all components with the provided build script:
+Clone the repository and build all components with the provided build script.
+
+On Linux or macOS:
 
 ```bash
 git clone https://github.com/IntegralPilot/rustc_codegen_jvm.git
 cd rustc_codegen_jvm
-
-# On Linux or macOS:
 ./build.py all
-# On Windows:
+```
+
+On Windows, enable symlinks during the initial checkout:
+
+```powershell
+git clone -c core.symlinks=true https://github.com/IntegralPilot/rustc_codegen_jvm.git
+cd rustc_codegen_jvm
 python build.py all
 ```
 

--- a/build.py
+++ b/build.py
@@ -44,13 +44,16 @@ class Config:
 
     # Platform-specific details
     if platform.system() == "Windows":
+        DYLIB_PREFIX = ""
         DYLIB_SUFFIX = ".dll"
     elif platform.system() == "Darwin":
+        DYLIB_PREFIX = "lib"
         DYLIB_SUFFIX = ".dylib"
     else:
+        DYLIB_PREFIX = "lib"
         DYLIB_SUFFIX = ".so"
         
-    RUST_BACKEND_DYLIB = ROOT_DIR / "target/release" / f"librustc_codegen_jvm{DYLIB_SUFFIX}"
+    RUST_BACKEND_DYLIB = ROOT_DIR / "target/release" / f"{DYLIB_PREFIX}rustc_codegen_jvm{DYLIB_SUFFIX}"
     JAVA_LINKER_EXE = JAVA_LINKER_DIR / "target/release/java-linker"
 
 # --- Helper Functions ---
@@ -195,8 +198,8 @@ def generate_config_files():
 
     # Logic from GenerateFiles.py is now integrated here
     replacements = {
-        "../../../": str(Config.ROOT_DIR) + os.sep,
-        ".dylib": Config.DYLIB_SUFFIX
+        "../../../": Config.ROOT_DIR.as_posix() + "/",
+        "@RUST_BACKEND_DYLIB@": Config.RUST_BACKEND_DYLIB.name,
     }
 
     for template_path in Config.ROOT_DIR.glob("*.template"):

--- a/config.toml.template
+++ b/config.toml.template
@@ -1,6 +1,6 @@
 [build]
 rustflags = [
-  "-Z", "codegen-backend=../../../target/release/librustc_codegen_jvm.dylib",
+  "-Z", "codegen-backend=../../../target/release/@RUST_BACKEND_DYLIB@",
   "-C", "linker=../../../java-linker/target/release/java-linker",
   "-C", "link-args=../../../library/build/libs/library-0.1.0.jar"
 ]

--- a/java-linker/src/main.rs
+++ b/java-linker/src/main.rs
@@ -91,8 +91,105 @@ fn record_instrumentation_duration(stage: &'static str, duration: Duration) {
     }
 }
 
+fn msvc_output_path(arg: &str) -> Option<&str> {
+    let prefix = arg.get(..5)?;
+    prefix.eq_ignore_ascii_case("/out:").then(|| &arg[5..])
+}
+
+fn jar_output_path(mut output_name: String) -> String {
+    if output_name.to_ascii_lowercase().ends_with(".exe") {
+        output_name.truncate(output_name.len() - ".exe".len());
+    }
+    if !output_name.to_ascii_lowercase().ends_with(".jar") {
+        output_name.push_str(".jar");
+    }
+    output_name
+}
+
+fn parse_response_lines(content: &str, msvc_quoting: bool) -> Vec<String> {
+    content
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim_end_matches('\r');
+            if line.is_empty() {
+                return None;
+            }
+
+            let line = if msvc_quoting {
+                line.strip_prefix('"')
+                    .and_then(|line| line.strip_suffix('"'))
+                    .unwrap_or(line)
+            } else {
+                line
+            };
+
+            let mut parsed = String::with_capacity(line.len());
+            let mut chars = line.chars().peekable();
+            while let Some(character) = chars.next() {
+                if character == '\\' {
+                    if msvc_quoting {
+                        if chars.peek() == Some(&'"') {
+                            parsed.push(chars.next().unwrap());
+                        } else {
+                            parsed.push(character);
+                        }
+                    } else if let Some(escaped) = chars.next() {
+                        parsed.push(escaped);
+                    } else {
+                        parsed.push(character);
+                    }
+                } else {
+                    parsed.push(character);
+                }
+            }
+            Some(parsed)
+        })
+        .collect()
+}
+
+fn read_response_file(path: &Path) -> io::Result<Vec<String>> {
+    let bytes = fs::read(path)?;
+    if bytes.starts_with(&[0xff, 0xfe]) {
+        let body = &bytes[2..];
+        if body.len() % 2 != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "UTF-16 response file has an odd byte length",
+            ));
+        }
+        let units: Vec<u16> = body
+            .chunks_exact(2)
+            .map(|bytes| u16::from_le_bytes([bytes[0], bytes[1]]))
+            .collect();
+        let content = String::from_utf16(&units)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        Ok(parse_response_lines(&content, true))
+    } else {
+        let content =
+            std::str::from_utf8(bytes.strip_prefix(&[0xef, 0xbb, 0xbf]).unwrap_or(&bytes))
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        Ok(parse_response_lines(content, false))
+    }
+}
+
+fn linker_args() -> io::Result<Vec<String>> {
+    let mut command_line = env::args();
+    let mut expanded = vec![command_line.next().unwrap_or_else(|| "java-linker".into())];
+    for arg in command_line {
+        if let Some(path) = arg.strip_prefix('@') {
+            expanded.extend(read_response_file(Path::new(path))?);
+        } else {
+            expanded.push(arg);
+        }
+    }
+    Ok(expanded)
+}
+
 fn main() -> Result<(), i32> {
-    let args: Vec<String> = env::args().collect();
+    let args = linker_args().map_err(|error| {
+        eprintln!("Error: Failed to read linker response file: {error}");
+        1
+    })?;
     if args.len() < 3 {
         eprintln!("Usage: java-linker <input_files...> -o <output_jar_file>");
         return Err(1);
@@ -110,16 +207,19 @@ fn main() -> Result<(), i32> {
         let arg = &args[i];
         if arg == "-o" {
             if i + 1 < args.len() {
-                let mut output_name = args[i + 1].clone();
-                if !output_name.ends_with(".jar") {
-                    output_name.push_str(".jar");
-                }
-                output_file = Some(output_name);
+                output_file = Some(jar_output_path(args[i + 1].clone()));
                 i += 2;
             } else {
                 eprintln!("Error: -o flag requires an output file path");
                 return Err(1);
             }
+        } else if let Some(output_name) = msvc_output_path(arg) {
+            if output_name.is_empty() {
+                eprintln!("Error: /OUT: flag requires an output file path");
+                return Err(1);
+            }
+            output_file = Some(jar_output_path(output_name.to_owned()));
+            i += 1;
         } else if !arg.starts_with('-') {
             // Collect potential input files, differentiating classes and JARs
             if arg.ends_with(".class") {
@@ -158,7 +258,7 @@ fn main() -> Result<(), i32> {
     let output_file_path = match output_file {
         Some(path) => path,
         None => {
-            eprintln!("Error: Output file (-o) not specified.");
+            eprintln!("Error: Output file (-o or /OUT:) not specified.");
             return Err(1);
         }
     };
@@ -847,4 +947,55 @@ fn create_manifest_content(main_class_name: Option<&str>) -> String {
     // Crucial: Ensure the manifest ends with a blank line (CRLF CRLF)
     manifest.push_str("\r\n");
     manifest
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{jar_output_path, msvc_output_path, parse_response_lines};
+
+    #[test]
+    fn recognizes_msvc_output_argument_case_insensitively() {
+        assert_eq!(
+            msvc_output_path("/OUT:C:\\tmp\\app.exe"),
+            Some("C:\\tmp\\app.exe")
+        );
+        assert_eq!(
+            msvc_output_path("/out:C:\\tmp\\app.exe"),
+            Some("C:\\tmp\\app.exe")
+        );
+        assert_eq!(msvc_output_path("/DEBUG"), None);
+    }
+
+    #[test]
+    fn converts_native_output_names_to_jar_names() {
+        assert_eq!(jar_output_path("target/app".into()), "target/app.jar");
+        assert_eq!(jar_output_path("target/app.exe".into()), "target/app.jar");
+        assert_eq!(jar_output_path("target/app.EXE".into()), "target/app.jar");
+        assert_eq!(jar_output_path("target/app.jar".into()), "target/app.jar");
+    }
+
+    #[test]
+    fn parses_rustc_msvc_response_file_lines() {
+        let content = concat!(
+            "\"C:\\project with spaces\\Main.class\"\n",
+            "\"/OUT:C:\\project with spaces\\app.exe\"\n",
+            "\"/PDBALTPATH:%_PDB%\"\n",
+        );
+        assert_eq!(
+            parse_response_lines(content, true),
+            [
+                "C:\\project with spaces\\Main.class",
+                "/OUT:C:\\project with spaces\\app.exe",
+                "/PDBALTPATH:%_PDB%",
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_rustc_gnu_response_file_lines() {
+        assert_eq!(
+            parse_response_lines("path\\ with\\ spaces/Main.class\n-o\noutput\n", false),
+            ["path with spaces/Main.class", "-o", "output"]
+        );
+    }
 }

--- a/jvm-unknown-unknown.json.template
+++ b/jvm-unknown-unknown.json.template
@@ -9,7 +9,7 @@
   "emit-debug-gdb-scripts": false,
   "exe-suffix": ".jar",
   "linker": "../../../java-linker/target/debug/java-linker",
-  "default-codegen-backend": "../../../target/debug/librustc_codegen_jvm.dylib",
+  "default-codegen-backend": "../../../target/debug/@RUST_BACKEND_DYLIB@",
   "max-atomic-width": 64,
   "metadata": {
     "description": "Java Bytecode",


### PR DESCRIPTION
This commit contains a set of changes that fixes a few build errors I had from building this project on Windows. I used Codex to implement the changes and checked they were sane by eye.

- Remove lib prefix for generated libraries
- Give instructions for correctly checking out symlinks on Windows (not enabled by default, which causes errors reading config.toml)
- Enable Windows as a build target in CI
- Change `python3` command to `python` to support both Unix and Windows
- Add support for java-linker to recognise /OUT as an argument
- Handles error case where generated path is too long for Windows to handle
  - Large commands cause rustc to pass linker arguments through a response-file
  - MSVC targets use UTF-16LE encoding for response file, which was not supported by java-linker
